### PR TITLE
Fixed multiple log handlers

### DIFF
--- a/hiclass/HierarchicalClassifier.py
+++ b/hiclass/HierarchicalClassifier.py
@@ -156,19 +156,20 @@ class HierarchicalClassifier(abc.ABC):
         self.logger_.setLevel(self.verbose)
 
         # Create console handler and set verbose level
-        ch = logging.StreamHandler()
-        ch.setLevel(self.verbose)
+        if not self.logger_.hasHandlers():
+            ch = logging.StreamHandler()
+            ch.setLevel(self.verbose)
 
-        # Create formatter
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
+            # Create formatter
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
 
-        # Add formatter to ch
-        ch.setFormatter(formatter)
+            # Add formatter to ch
+            ch.setFormatter(formatter)
 
-        # Add ch to logger
-        self.logger_.addHandler(ch)
+            # Add ch to logger
+            self.logger_.addHandler(ch)
 
     def _disambiguate(self):
         self.separator_ = "::HiClass::Separator::"


### PR DESCRIPTION
During hyperparameter optimisation of a hiclass classifier, `HierarchicalClassifier._create_logger()` adds a new `StreamHandler` to the logger every time a classifier is instantiated. This means that on the nth iteration of a hyperparameter tuning session (or indeed any time a hiclass classifier is instantiated repeatedly) every log line in the console is repeated n times.

By checking if a hander is already set on the logger, we can skip adding another one when `_create_logger()` is callled