### PR TITLE
Remove fetch-depth

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -60,7 +60,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-        fetch-depth: '0'
     - name: Install pypa/build
       run: |
         git fetch --tags


### PR DESCRIPTION
This PR removes the warning message `Unexpected input(s) 'fetch-depth', valid inputs are ['python-version', 'cache', 'architecture', 'token', 'cache-dependency-path']` from the publishing pipeline.